### PR TITLE
Do not require importlib_metadata on py3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "pynacl>=0.3.0",
         "typing_extensions>=3.5",
         'typing>=3.5;python_version<"3.5"',
-        "importlib_metadata",
+        'importlib_metadata;python_version<"3.8"',
     ],
     long_description=read_file(("README.rst",)),
     keywords="json",

--- a/signedjson/__init__.py
+++ b/signedjson/__init__.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib_metadata import version, PackageNotFoundError
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    from importlib_metadata import version, PackageNotFoundError
 
 try:
     __version__ = version(__name__)

--- a/signedjson/__init__.py
+++ b/signedjson/__init__.py
@@ -14,7 +14,7 @@
 
 try:
     from importlib.metadata import version, PackageNotFoundError
-except ImportError: # pragma: no cover
+except ImportError: # pragma: nocover
     from importlib_metadata import version, PackageNotFoundError
 
 try:

--- a/signedjson/__init__.py
+++ b/signedjson/__init__.py
@@ -14,7 +14,7 @@
 
 try:
     from importlib.metadata import version, PackageNotFoundError
-except ImportError: # pragma: nocover
+except ImportError:  # pragma: nocover
     from importlib_metadata import version, PackageNotFoundError
 
 try:

--- a/signedjson/__init__.py
+++ b/signedjson/__init__.py
@@ -14,7 +14,7 @@
 
 try:
     from importlib.metadata import version, PackageNotFoundError
-except ImportError:
+except ImportError: # pragma: no cover
     from importlib_metadata import version, PackageNotFoundError
 
 try:


### PR DESCRIPTION
importlib-metadata is already part of the standard library on Python 3.8. This should also make the project compatible with Python 3.8.