### PR TITLE
Do not require typing_extensions on python 3.8+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,13 @@ setup(
         "canonicaljson>=1.0.0",
         "unpaddedbase64>=1.0.1",
         "pynacl>=0.3.0",
-        "typing_extensions>=3.5",
+        'typing_extensions>=3.5;python_version<"3.8"',
         'typing>=3.5;python_version<"3.5"',
         'importlib_metadata;python_version<"3.8"',
     ],
+    extras_require={
+        "dev": ["typing_extensions>=3.5"],
+    },
     long_description=read_file(("README.rst",)),
     keywords="json",
 )

--- a/signedjson/types.py
+++ b/signedjson/types.py
@@ -13,8 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+from typing import TYPE_CHECKING
+
 import nacl.signing
-from typing_extensions import Protocol
+
+if TYPE_CHECKING or sys.version_info < (3, 8, 0):
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol
 
 
 class BaseKey(Protocol):


### PR DESCRIPTION
Protocol is a part of typing since python 3.8 https://docs.python.org/3/library/typing.html#typing.Protocol