### PR TITLE
Use assertEqual for Python 3.11 compatibility

### DIFF
--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -19,8 +19,8 @@ class GenerateTestCase(unittest.TestCase):
     def test_generate_key(self):
         my_version = "my_version"
         my_key = generate_signing_key(my_version)
-        self.assertEquals(my_key.alg, "ed25519")
-        self.assertEquals(my_key.version, my_version)
+        self.assertEqual(my_key.alg, 'ed25519')
+        self.assertEqual(my_key.version, my_version)
 
 
 class DecodeTestCase(unittest.TestCase):
@@ -35,8 +35,8 @@ class DecodeTestCase(unittest.TestCase):
         decoded_key = decode_signing_key_base64(
             "ed25519", self.version, self.key_base64
         )
-        self.assertEquals(decoded_key.alg, "ed25519")
-        self.assertEquals(decoded_key.version, self.version)
+        self.assertEqual(decoded_key.alg, 'ed25519')
+        self.assertEqual(decoded_key.version, self.version)
 
     def test_decode_invalid_base64(self):
         with self.assertRaises(Exception):
@@ -54,8 +54,8 @@ class DecodeTestCase(unittest.TestCase):
         decoded_key = decode_verify_key_base64(
             "ed25519", self.version, self.verify_key_base64
         )
-        self.assertEquals(decoded_key.alg, "ed25519")
-        self.assertEquals(decoded_key.version, self.version)
+        self.assertEqual(decoded_key.alg, 'ed25519')
+        self.assertEqual(decoded_key.version, self.version)
 
     def test_decode_verify_key_invalid_base64(self):
         with self.assertRaises(Exception):
@@ -72,12 +72,12 @@ class DecodeTestCase(unittest.TestCase):
     def test_read_keys(self):
         stream = ["ed25519 %s %s" % (self.version, self.key_base64)]
         keys = read_signing_keys(stream)
-        self.assertEquals(len(keys), 1)
+        self.assertEqual(len(keys), 1)
 
     def test_read_old_keys(self):
         stream = ["ed25519 %s 0 %s" % (self.version, self.verify_key_base64)]
         keys = read_old_signing_keys(stream)
-        self.assertEquals(len(keys), 1)
+        self.assertEqual(len(keys), 1)
 
     def test_decode_verify_invalid_algorithm(self):
         with self.assertRaises(Exception):

--- a/tests/test_known_key.py
+++ b/tests/test_known_key.py
@@ -41,7 +41,7 @@ class KnownKeyTestCase(unittest.TestCase):
         self.signing_key.version = KEY_VER
 
     def test_sign_minimal(self):
-        self.assertEquals(
+        self.assertEqual(
             sign_json({}, "domain", self.signing_key),
             {
                 'signatures': {
@@ -54,7 +54,7 @@ class KnownKeyTestCase(unittest.TestCase):
         )
 
     def test_sign_with_data(self):
-        self.assertEquals(
+        self.assertEqual(
             sign_json({'one': 1, 'two': "Two"}, "domain", self.signing_key),
             {
                 'one': 1,


### PR DESCRIPTION
`assertEquals` has been deprecated since Python 3.2 and is removed in 3.11. Use `assertEqual` instead.

https://docs.python.org/3.11/whatsnew/3.11.html#removed
