### PR TITLE
Linting and broadcast type annotations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,14 @@
+# Ideally this would be in pyproject.toml, but that's not possible right now. See
+#     https://github.com/PyCQA/flake8/issues/234
+#     https://github.com/johnthagen/python-blueprint/issues/29#issuecomment-1003437646
+[flake8]
+# see https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
+# and https://flake8.pycqa.org/en/latest/user/error-codes.html
+# for error codes. The ones we ignore are:
+#  W503: line break before binary operator
+#  W504: line break after binary operator
+#  E203: whitespace before ':' (which is contrary to pep8?)
+#  E731: do not assign a lambda expression, use a def
+#  E501: Line too long (black enforces this for us)
+ignore=W503,W504,E203,E731,E501
+exclude=dist,.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,11 @@ known_first_party = ["signedjson", "tests"]
 
 [tool.black]
 # Placeholder for now.
+
+[tool.mypy]
+files = ["signedjson", "tests"]
+show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = ["canonicaljson"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,6 @@ multi_line_output = 3
 include_trailing_comma = true
 combine_as_imports = true
 known_first_party = ["signedjson", "tests"]
+
+[tool.black]
+# Placeholder for now.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,10 @@
         directory = "misc"
         name = "Internal Changes"
         showcontent = true
+
+[tool.isort]
+line_length = 88
+multi_line_output = 3
+include_trailing_comma = true
+combine_as_imports = true
+known_first_party = ["signedjson", "tests"]

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,7 @@ setup(
     },
     long_description=read_file(("README.rst",)),
     keywords="json",
+    package_data={
+        "signedjson": ["py.typed"]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import setup
-from codecs import open
 import os
+from codecs import open
+
+from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/signedjson/__init__.py
+++ b/signedjson/__init__.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 try:
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
 except ImportError:  # pragma: nocover
-    from importlib_metadata import version, PackageNotFoundError
+    from importlib_metadata import PackageNotFoundError, version
 
 try:
     __version__ = version(__name__)

--- a/signedjson/__init__.py
+++ b/signedjson/__init__.py
@@ -15,7 +15,10 @@
 try:
     from importlib.metadata import PackageNotFoundError, version
 except ImportError:  # pragma: nocover
-    from importlib_metadata import PackageNotFoundError, version
+    from importlib_metadata import (  # type: ignore[import, no-redef]
+        PackageNotFoundError,
+        version,
+    )
 
 try:
     __version__ = version(__name__)

--- a/signedjson/key.py
+++ b/signedjson/key.py
@@ -20,7 +20,7 @@ from typing import Iterable, List, TextIO
 import nacl.signing
 from unpaddedbase64 import decode_base64, encode_base64
 
-from signedjson.types import SigningKey, VerifyKey
+from signedjson.types import SigningKey, VerifyKey, VerifyKeyWithExpiry
 
 NACL_ED25519 = "ed25519"
 SUPPORTED_ALGORITHMS = [NACL_ED25519]
@@ -34,7 +34,7 @@ def generate_signing_key(version):
     Returns:
         A SigningKey object.
     """
-    key = nacl.signing.SigningKey.generate()
+    key: SigningKey = nacl.signing.SigningKey.generate()  # type: ignore[assignment]
     key.version = version
     key.alg = NACL_ED25519
     return key
@@ -43,7 +43,7 @@ def generate_signing_key(version):
 def get_verify_key(signing_key):
     # type: (SigningKey) -> VerifyKey
     """Get a verify key from a signing key"""
-    verify_key = signing_key.verify_key
+    verify_key: VerifyKey = signing_key.verify_key  # type: ignore[assignment]
     verify_key.version = signing_key.version
     verify_key.alg = signing_key.alg
     return verify_key
@@ -61,7 +61,7 @@ def decode_signing_key_base64(algorithm, version, key_base64):
     """
     if algorithm == NACL_ED25519:
         key_bytes = decode_base64(key_base64)
-        key = nacl.signing.SigningKey(key_bytes)
+        key: SigningKey = nacl.signing.SigningKey(key_bytes)  # type: ignore[assignment]
         key.version = version
         key.alg = NACL_ED25519
         return key
@@ -126,7 +126,7 @@ def decode_verify_key_bytes(key_id, key_bytes):
     """
     if key_id.startswith(NACL_ED25519 + ":"):
         version = key_id[len(NACL_ED25519) + 1 :]
-        key = nacl.signing.VerifyKey(key_bytes)
+        key: VerifyKey = nacl.signing.VerifyKey(key_bytes)  # type: ignore[assignment]
         key.version = version
         key.alg = NACL_ED25519
         return key
@@ -151,7 +151,7 @@ def read_signing_keys(stream):
 
 
 def read_old_signing_keys(stream):
-    # type: (Iterable[str]) -> List[VerifyKey]
+    # type: (Iterable[str]) -> List[VerifyKeyWithExpiry]
     """Reads a list of old keys from a stream
     Args:
         stream : A stream to iterate for keys.
@@ -161,7 +161,9 @@ def read_old_signing_keys(stream):
     keys = []
     for line in stream:
         algorithm, version, expired, key_base64 = line.split()
-        key = decode_verify_key_base64(algorithm, version, key_base64)
+        key: VerifyKeyWithExpiry = decode_verify_key_base64(
+            algorithm, version, key_base64
+        )  # type: ignore[assignment]
         key.expired = int(expired)
         keys.append(key)
     return keys

--- a/signedjson/key.py
+++ b/signedjson/key.py
@@ -125,7 +125,7 @@ def decode_verify_key_bytes(key_id, key_bytes):
         A VerifyKey object.
     """
     if key_id.startswith(NACL_ED25519 + ":"):
-        version = key_id[len(NACL_ED25519) + 1:]
+        version = key_id[len(NACL_ED25519) + 1 :]
         key = nacl.signing.VerifyKey(key_bytes)
         key.version = version
         key.alg = NACL_ED25519
@@ -176,4 +176,11 @@ def write_signing_keys(stream, keys):
     """
     for key in keys:
         key_base64 = encode_signing_key_base64(key)
-        stream.write("%s %s %s\n" % (key.alg, key.version, key_base64,))
+        stream.write(
+            "%s %s %s\n"
+            % (
+                key.alg,
+                key.version,
+                key_base64,
+            )
+        )

--- a/signedjson/sign.py
+++ b/signedjson/sign.py
@@ -61,8 +61,9 @@ def sign_json(json_object, signature_name, signing_key):
     return json_object
 
 
-def signature_ids(json_object, signature_name,
-                  supported_algorithms=SUPPORTED_ALGORITHMS):
+def signature_ids(
+    json_object, signature_name, supported_algorithms=SUPPORTED_ALGORITHMS
+):
     # type: (JsonDict, str, Iterable[str]) -> List[str]
     """Does the JSON object have a signature for the given name?
     Args:
@@ -75,13 +76,13 @@ def signature_ids(json_object, signature_name,
     """
     key_ids = json_object.get("signatures", {}).get(signature_name, {}).keys()
     return list(
-        key_id for key_id in key_ids
-        if key_id.split(":")[0] in supported_algorithms
+        key_id for key_id in key_ids if key_id.split(":")[0] in supported_algorithms
     )
 
 
 class SignatureVerifyException(Exception):
     """A signature could not be verified"""
+
     pass
 
 
@@ -131,7 +132,10 @@ def verify_signed_json(json_object, signature_name, verify_key):
         verify_key.verify(message, signature)
     except Exception as e:
         raise SignatureVerifyException(
-            "Unable to verify signature for %s: %s %s" % (
-                signature_name, type(e), e,
+            "Unable to verify signature for %s: %s %s"
+            % (
+                signature_name,
+                type(e),
+                e,
             )
         )

--- a/signedjson/types.py
+++ b/signedjson/types.py
@@ -43,6 +43,10 @@ class VerifyKey(BaseKey):
         pass  # pragma: nocover
 
 
+class VerifyKeyWithExpiry(VerifyKey):
+    expired: int
+
+
 class SigningKey(BaseKey):
     """The private part of a key pair, for use with sign_json"""
 

--- a/signedjson/types.py
+++ b/signedjson/types.py
@@ -26,28 +26,31 @@ else:
 
 class BaseKey(Protocol):
     """Common base type for VerifyKey and SigningKey"""
+
     version = ""  # type: str
     alg = ""  # type: str
 
     def encode(self):
         # type: () -> bytes
-        pass   # pragma: nocover
+        pass  # pragma: nocover
 
 
 class VerifyKey(BaseKey):
     """The public part of a key pair, for use with verify_signed_json"""
+
     def verify(self, message, signature):
         # type: (bytes, bytes) -> bytes
-        pass   # pragma: nocover
+        pass  # pragma: nocover
 
 
 class SigningKey(BaseKey):
     """The private part of a key pair, for use with sign_json"""
+
     def sign(self, message):
         # type: (bytes) -> nacl.signing.SignedMessage
-        pass   # pragma: nocover
+        pass  # pragma: nocover
 
     @property
     def verify_key(self):
         # type: () -> nacl.signing.VerifyKey
-        pass   # pragma: nocover
+        pass  # pragma: nocover

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -19,7 +19,7 @@ class GenerateTestCase(unittest.TestCase):
     def test_generate_key(self):
         my_version = "my_version"
         my_key = generate_signing_key(my_version)
-        self.assertEqual(my_key.alg, 'ed25519')
+        self.assertEqual(my_key.alg, "ed25519")
         self.assertEqual(my_key.version, my_version)
 
 
@@ -35,7 +35,7 @@ class DecodeTestCase(unittest.TestCase):
         decoded_key = decode_signing_key_base64(
             "ed25519", self.version, self.key_base64
         )
-        self.assertEqual(decoded_key.alg, 'ed25519')
+        self.assertEqual(decoded_key.alg, "ed25519")
         self.assertEqual(decoded_key.version, self.version)
 
     def test_decode_invalid_base64(self):
@@ -54,7 +54,7 @@ class DecodeTestCase(unittest.TestCase):
         decoded_key = decode_verify_key_base64(
             "ed25519", self.version, self.verify_key_base64
         )
-        self.assertEqual(decoded_key.alg, 'ed25519')
+        self.assertEqual(decoded_key.alg, "ed25519")
         self.assertEqual(decoded_key.version, self.version)
 
     def test_decode_verify_key_invalid_base64(self):

--- a/tests/test_known_key.py
+++ b/tests/test_known_key.py
@@ -21,9 +21,7 @@ from unpaddedbase64 import decode_base64
 
 from signedjson.sign import sign_json
 
-SIGNING_KEY_SEED = decode_base64(
-    "YJDBA9Xnr2sVqXD9Vj7XVUnmFZcZrlw8Md7kMW+3XA1"
-)
+SIGNING_KEY_SEED = decode_base64("YJDBA9Xnr2sVqXD9Vj7XVUnmFZcZrlw8Md7kMW+3XA1")
 
 KEY_ALG = "ed25519"
 KEY_VER = 1
@@ -31,8 +29,8 @@ KEY_NAME = "%s:%d" % (KEY_ALG, KEY_VER)
 
 
 class KnownKeyTestCase(unittest.TestCase):
-    """ An entirely deterministic test using a given signing key seed, so that
-    other implementations can compare that they get the same result. """
+    """An entirely deterministic test using a given signing key seed, so that
+    other implementations can compare that they get the same result."""
 
     def setUp(self):
         self.signing_key = nacl.signing.SigningKey(SIGNING_KEY_SEED)
@@ -43,26 +41,26 @@ class KnownKeyTestCase(unittest.TestCase):
         self.assertEqual(
             sign_json({}, "domain", self.signing_key),
             {
-                'signatures': {
-                    'domain': {
+                "signatures": {
+                    "domain": {
                         KEY_NAME: "K8280/U9SSy9IVtjBuVeLr+HpOB4BQFWbg+UZaADMt"
                         "TdGYI7Geitb76LTrr5QV/7Xg4ahLwYGYZzuHGZKM5ZAQ"
                     },
                 }
-            }
+            },
         )
 
     def test_sign_with_data(self):
         self.assertEqual(
-            sign_json({'one': 1, 'two': "Two"}, "domain", self.signing_key),
+            sign_json({"one": 1, "two": "Two"}, "domain", self.signing_key),
             {
-                'one': 1,
-                'two': "Two",
-                'signatures': {
-                    'domain': {
+                "one": 1,
+                "two": "Two",
+                "signatures": {
+                    "domain": {
                         KEY_NAME: "KqmLSbO39/Bzb0QIYE82zqLwsA+PDzYIpIRA2sRQ4s"
                         "L53+sN6/fpNSoqE7BP7vBZhG6kYdD13EIMJpvhJI+6Bw"
                     },
-                }
-            }
+                },
+            },
         )

--- a/tests/test_known_key.py
+++ b/tests/test_known_key.py
@@ -16,9 +16,8 @@
 
 import unittest
 
-from unpaddedbase64 import decode_base64
-
 import nacl.signing
+from unpaddedbase64 import decode_base64
 
 from signedjson.sign import sign_json
 

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -28,48 +28,45 @@ from signedjson.sign import (
 
 class JsonSignTestCase(unittest.TestCase):
     def setUp(self):
-        self.message = {'foo': 'bar', 'unsigned': {}}
+        self.message = {"foo": "bar", "unsigned": {}}
         self.sigkey = MockSigningKey()
-        self.assertEqual(self.sigkey.alg, 'mock')
-        self.signed = sign_json(self.message, 'Alice', self.sigkey)
+        self.assertEqual(self.sigkey.alg, "mock")
+        self.signed = sign_json(self.message, "Alice", self.sigkey)
         self.verkey = MockVerifyKey()
 
     def test_sign_and_verify(self):
-        self.assertIn('signatures', self.signed)
-        self.assertIn('Alice', self.signed['signatures'])
-        self.assertIn('mock:test', self.signed['signatures']['Alice'])
+        self.assertIn("signatures", self.signed)
+        self.assertIn("Alice", self.signed["signatures"])
+        self.assertIn("mock:test", self.signed["signatures"]["Alice"])
         self.assertEqual(
-            self.signed['signatures']['Alice']['mock:test'],
-            encode_base64(b'x_______')
+            self.signed["signatures"]["Alice"]["mock:test"], encode_base64(b"x_______")
         )
         self.assertEqual(self.sigkey.signed_bytes, b'{"foo":"bar"}')
-        verify_signed_json(self.signed, 'Alice', self.verkey)
+        verify_signed_json(self.signed, "Alice", self.verkey)
 
     def test_signature_ids(self):
-        key_ids = signature_ids(
-            self.signed, 'Alice', supported_algorithms=['mock']
-        )
-        self.assertListEqual(key_ids, ['mock:test'])
+        key_ids = signature_ids(self.signed, "Alice", supported_algorithms=["mock"])
+        self.assertListEqual(key_ids, ["mock:test"])
 
     def test_verify_fail(self):
-        self.signed['signatures']['Alice']['mock:test'] = encode_base64(
-            b'not a signature'
+        self.signed["signatures"]["Alice"]["mock:test"] = encode_base64(
+            b"not a signature"
         )
         with self.assertRaises(SignatureVerifyException):
-            verify_signed_json(self.signed, 'Alice', self.verkey)
+            verify_signed_json(self.signed, "Alice", self.verkey)
 
     def test_verify_fail_no_signatures(self):
         with self.assertRaises(SignatureVerifyException):
-            verify_signed_json({}, 'Alice', self.verkey)
+            verify_signed_json({}, "Alice", self.verkey)
 
     def test_verify_fail_no_signature_for_alice(self):
         with self.assertRaises(SignatureVerifyException):
-            verify_signed_json({'signatures': {}}, 'Alice', self.verkey)
+            verify_signed_json({"signatures": {}}, "Alice", self.verkey)
 
     def test_verify_fail_not_base64(self):
-        invalid = {'signatures': {'Alice': {'mock:test': 'not base64'}}}
+        invalid = {"signatures": {"Alice": {"mock:test": "not base64"}}}
         with self.assertRaises(SignatureVerifyException):
-            verify_signed_json(invalid, 'Alice', self.verkey)
+            verify_signed_json(invalid, "Alice", self.verkey)
 
 
 class MockSigningKey(object):

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -19,7 +19,10 @@ import unittest
 from unpaddedbase64 import encode_base64
 
 from signedjson.sign import (
-    sign_json, verify_signed_json, signature_ids, SignatureVerifyException
+    SignatureVerifyException,
+    sign_json,
+    signature_ids,
+    verify_signed_json,
 )
 
 


### PR DESCRIPTION
Best reviewed commit-by-commit.

I've tested this manually with

```shell
python -m venv env
pip install isort mypy black -e .
isort signedjson tests
black signedjson tests
mypy signedjson tests
```

Pulled out of upcoming changes for a poetry-based CI run.