### PR TITLE
Mark key types as `SupportsBytes`

### DIFF
--- a/signedjson/types.py
+++ b/signedjson/types.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, SupportsBytes
 
 import nacl.signing
 
@@ -24,7 +24,7 @@ else:
     from typing import Protocol
 
 
-class BaseKey(Protocol):
+class BaseKey(Protocol, SupportsBytes):
     """Common base type for VerifyKey and SigningKey"""
 
     version = ""  # type: str

--- a/signedjson/types.py
+++ b/signedjson/types.py
@@ -56,5 +56,7 @@ class SigningKey(BaseKey):
 
     @property
     def verify_key(self):
+        # Note: use `signedjson.key.get_verify_key` to get a
+        # `signedjson.types.VerifyKey`.
         # type: () -> nacl.signing.VerifyKey
         pass  # pragma: nocover


### PR DESCRIPTION
pynacl's SigningKey and VerifyKey both expose a `__bytes__` method, so
this is correct. It's just that the information gets lost when we
replace these with our Protocol types.

While I'm at it, add a drive-by-comment.

Blocks https://github.com/matrix-org/synapse/pull/12326.