### PR TITLE
Expose `__bytes__` on Key protocols

### DIFF
--- a/signedjson/types.py
+++ b/signedjson/types.py
@@ -59,5 +59,7 @@ class SigningKey(BaseKey):
 
     @property
     def verify_key(self):
+        # Note: use `signedjson.key.get_verify_key` to get a
+        # `signedjson.types.VerifyKey`.
         # type: () -> nacl.signing.VerifyKey
         pass  # pragma: nocover

--- a/signedjson/types.py
+++ b/signedjson/types.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import sys
-from typing import TYPE_CHECKING, SupportsBytes
+from typing import TYPE_CHECKING
 
 import nacl.signing
 
@@ -24,7 +24,7 @@ else:
     from typing import Protocol
 
 
-class BaseKey(Protocol, SupportsBytes):
+class BaseKey(Protocol):
     """Common base type for VerifyKey and SigningKey"""
 
     version = ""  # type: str
@@ -56,7 +56,5 @@ class SigningKey(BaseKey):
 
     @property
     def verify_key(self):
-        # Note: use `signedjson.key.get_verify_key` to get a
-        # `signedjson.types.VerifyKey`.
         # type: () -> nacl.signing.VerifyKey
         pass  # pragma: nocover

--- a/signedjson/types.py
+++ b/signedjson/types.py
@@ -30,6 +30,9 @@ class BaseKey(Protocol):
     version = ""  # type: str
     alg = ""  # type: str
 
+    def __bytes__(self) -> bytes:
+        pass
+
     def encode(self):
         # type: () -> bytes
         pass  # pragma: nocover


### PR DESCRIPTION
My first attempt (inheriting from `SupportsBytes`) was fine as far as
mypy was concerned. But this failed with an MRO problem.

I suspect you're not supposed to actually inherit from `SupportsBytes`.
Or maybe `SupportsBytes` is itself a `Protocol` and there was some
inheritance ambiguity there.

Tested as follows:

```
$ python -m unittest tests/*
.......................
----------------------------------------------------------------------
Ran 23 tests in 0.002s

OK

$ mypy
signedjson/__init__.py:18: error: Incompatible import of "PackageNotFoundError" (imported name has type "Type[importlib_metadata.PackageNotFoundError]", local name has type "Type[importlib.metadata.PackageNotFoundError]")  [misc]
signedjson/__init__.py:18: note: Error code "misc" not covered by "type: ignore" comment
Found 1 error in 1 file (checked 8 source files)
```

The mypy complaints aren't new.

